### PR TITLE
Move .info into the right folder

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -30,5 +30,5 @@ build() {
 
 package() {
   install -Dm644 "${_gitname}/${_libname}.so" "${pkgdir}/usr/lib/libretro/${_libname}.so"
-  install -Dm644 "${_libname}.info" "${pkgdir}/usr/lib/libretro/${_libname}.info"
+  install -Dm644 "${_libname}.info" "${pkgdir}/usr/share/libretro/info/${_libname}.info"
 }


### PR DESCRIPTION
```mednafen_supergrafx_libretro.info``` is not a lib and it should be in ```/usr/share/libretro/info``` instead of ```/usr/lib/libretro```. Plus, it matches how retroarch is configured in the community repo.