### PR TITLE
Remove .info

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,10 +13,8 @@ makedepends=('git')
 
 _libname=mednafen_supergrafx_libretro
 _gitname=beetle-supergrafx-libretro
-source=("git+https://github.com/libretro/${_gitname}.git"
-        "https://raw.github.com/libretro/libretro-super/master/dist/info/${_libname}.info")
-md5sums=('SKIP'
-         'SKIP')
+source=("git+https://github.com/libretro/${_gitname}.git")
+md5sums=('SKIP')
 
 pkgver() {
   cd "${_gitname}"
@@ -30,5 +28,4 @@ build() {
 
 package() {
   install -Dm644 "${_gitname}/${_libname}.so" "${pkgdir}/usr/lib/libretro/${_libname}.so"
-  install -Dm644 "${_libname}.info" "${pkgdir}/usr/lib/libretro/${_libname}.info"
 }


### PR DESCRIPTION
.info is now in libretro-core-info and it should be removed from this package, otherwise there will be a conflict.